### PR TITLE
Add endpoint to fetch open issues count

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from github import Github
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -77,6 +78,9 @@ activities = {
     }
 }
 
+# Initialize GitHub client
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+github_client = Github(GITHUB_TOKEN)
 
 @app.get("/")
 def root():
@@ -130,3 +134,14 @@ def unregister_from_activity(activity_name: str, email: str):
     # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}
+
+
+@app.get("/issues/open")
+def get_open_issues():
+    """Fetch the number of open issues in the repository."""
+    try:
+        repo = github_client.get_repo("higgn/skills-integrate-mcp-with-copilot")
+        open_issues_count = repo.open_issues_count
+        return {"open_issues": open_issues_count}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error fetching open issues: {str(e)}")


### PR DESCRIPTION
This pull request adds a new endpoint `/issues/open` to fetch the number of open issues in the repository using the GitHub API.